### PR TITLE
Updating the URL helper options.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "argo-clf": ">=0.0.3",
     "argo-formatter": ">=0.0.0",
     "argo-gzip": ">=0.2.0",
-    "argo-url-helper": ">=0.2.0"
+    "argo-url-helper": ">=0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "titan",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A stellar API framework built on top of Argo.",
   "main": "titan.js",
   "scripts": {

--- a/titan.js
+++ b/titan.js
@@ -14,6 +14,10 @@ var ManualResourceFactory = require('./resource_factories/manual');
 
 var Titan = function(options) {
   options = options || {};
+  var urlHelperOpts = {};
+  if(typeof options.useXForwardedHostHeader !== 'undefined') {
+    urlHelperOpts.useXForwardedHostHeader = options.useXForwardedHostHeader;
+  }
   this.argo = options.argo || argo();
   this.formatter = null;
 
@@ -21,7 +25,7 @@ var Titan = function(options) {
 
   this.argo
     .use(router)
-    .use(urlHelper);
+    .use(urlHelper(urlHelperOpts));
 };
 
 ['use', 'route', 'map', 'build', 'get', 'post',


### PR DESCRIPTION
- Allows for the passing of global argo-url-helper option `useXForwardedHostHeader`