### PR TITLE
Add Support for X-Forwarded-Root

### DIFF
--- a/titan.js
+++ b/titan.js
@@ -18,8 +18,8 @@ var Titan = function(options) {
   if(typeof options.useXForwardedHostHeader !== 'undefined') {
     urlHelperOpts.useXForwardedHostHeader = options.useXForwardedHostHeader;
   }
-  if(typeof options.useXForwardedRootHeader !== 'undefined') {
-    urlHelperOpts.useXForwardedRootHeader = options.useXForwardedRootHeader;
+  if(typeof options.useXForwardedPathHeader !== 'undefined') {
+    urlHelperOpts.useXForwardedPathHeader = options.useXForwardedPathHeader;
   }
   this.argo = options.argo || argo();
   this.formatter = null;

--- a/titan.js
+++ b/titan.js
@@ -18,6 +18,9 @@ var Titan = function(options) {
   if(typeof options.useXForwardedHostHeader !== 'undefined') {
     urlHelperOpts.useXForwardedHostHeader = options.useXForwardedHostHeader;
   }
+  if(typeof options.useXForwardedRootHeader !== 'undefined') {
+    urlHelperOpts.useXForwardedRootHeader = options.useXForwardedRootHeader;
+  }
   this.argo = options.argo || argo();
   this.formatter = null;
 
@@ -81,7 +84,7 @@ Titan.prototype.allow = function(options) {
       maxAge: '432000'
     };
   }
-  
+
   this.argo.use(function(handle) {
     handle('response', function(env, next) {
       if (options.origins) {


### PR DESCRIPTION
Pass along "X-Forwarded-Root" support to the `argo-url-helper` module
options.

Depends on `argo-url-helper` PR argo/argo-url-helper#4.
